### PR TITLE
minian v2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "minian" %}
-{% set version = "1.3.0" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/minian-{{ version }}.tar.gz
-  sha256: bfc7e781228b148d8a004c1692fa239773a1a7754795ee3b536e955e969aca77
+  sha256: ee5a0b6458408efa542342ca84e74be8a3ce756421b9507a1552b26c44b06c49
 
 build:
   noarch: python
@@ -42,6 +42,7 @@ requirements:
     - opencv >=4.2.0.34
     - pandas >=1.2.3
     - panel >=0.8.0
+    - pooch >=1.6.0
     - pyfftw >=0.12.0
     - rechunker >=0.3.3
     - scikit-image >=0.18.1
@@ -53,6 +54,7 @@ requirements:
     - sparse >=0.11.2
     - statsmodels >=0.11.1
     - tifffile
+    - typing_extensions >=4.0
     - xarray >=0.17.0
     - zarr
 
@@ -60,6 +62,7 @@ test:
   imports:
     - minian
   commands:
+    - minian --help
     - minian-install --help
     - pip check
   requires:


### PR DESCRIPTION
## Update minian to 2.0.0

Bumps the recipe from **1.3.0** (shipped in #35) to **2.0.0**, sourced from the PyPI sdist. minian 2.0.0 is live on PyPI.

### Changes
- **version** 1.3.0 -> 2.0.0; new sdist `sha256` (`ee5a0b6458408efa542342ca84e74be8a3ce756421b9507a1552b26c44b06c49`).
- **run deps** synced from the 2.0 `pyproject.toml`: added **`pooch >=1.6.0`** and **`typing_extensions >=4.0`** (both new core runtime deps in v2). All other deps unchanged from the 1.3.0 recipe.
- **test** now also runs **`minian --help`**: v2 adds `minian` as the canonical CLI (`minian-install` is kept as a deprecated alias). Both entry points are created automatically by `pip install .` from `[project.scripts]`.

### Notes
- Supersedes the stale autotick PRs #36 (1.3.0, already shipped via #35) and #37 (2.0.0), both branched off the pre-#35 1.2.1 GitHub-archive recipe and now closed.
- No re-render needed (recipe-only change, no new selectors/build config).

### Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for the new version)
- [x] Ensured the license file is being packaged (`license_file: LICENSE`)
- [x] Dependencies updated per upstream `pyproject.toml`
