### PR TITLE
Re-enable bot automerge

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  automerge: false
+  automerge: true
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true


### PR DESCRIPTION
## Re-enable bot automerge

Flips `bot.automerge` back to `true` in `conda-forge.yml`.

It was temporarily set to `false` during the 1.3.0 modernization (#35) so that the imminent autotick `1.3.0 -> 2.0.0` bump couldn't auto-merge a v2 recipe before its new run-deps (`pooch`, `typing_extensions`) and the canonical `minian` entry point were verified. v2.0.0 has now landed correctly (#39), so the steady v2.x autotick line can resume auto-merging green version bumps.
